### PR TITLE
Fix #153 refactor test beforeEach to before (coverage 100%)

### DIFF
--- a/solidity/test/etherCollector.test.js
+++ b/solidity/test/etherCollector.test.js
@@ -1,171 +1,148 @@
-import EVMRevert from 'openzeppelin-solidity/test/helpers/EVMRevert'
-import EVMThrow from 'openzeppelin-solidity/test/helpers/EVMThrow'
+import EVMRevert from "openzeppelin-solidity/test/helpers/EVMRevert";
+import EVMThrow from "openzeppelin-solidity/test/helpers/EVMThrow";
 
-const wweb3 = require('web3')
+const Web3 = require("web3");
+const wweb3 = new Web3();
 const BigNumber = web3.BigNumber;
-
-const should = require('chai')
-    .use(require('chai-as-promised'))
-    .use(require('chai-bignumber')(BigNumber))
+const should = require("chai")
+    .use(require("chai-as-promised"))
+    .use(require("chai-bignumber")(BigNumber))
     .should();
 
-const Kernel = artifacts.require('kernel/Kernel');
+const Kernel = artifacts.require("kernel/Kernel");
+const EtherCollector = artifacts.require("collector/EtherCollector");
+const EtherCollectorStorage = artifacts.require("collector/EtherCollectorStorage");
 
-const EtherCollector = artifacts.require('collector/EtherCollector');
-const EtherCollectorStorage = artifacts.require('collector/EtherCollectorStorage');
+const ACLHandler  = artifacts.require("handler/ACLHandler");
+const ContractAddressHandler = artifacts.require("handler/ContractAddressHandler");
 
-const ACLHandler  = artifacts.require('handler/ACLHandler');
-const ContractAddressHandler = artifacts.require('handler/ContractAddressHandler');
+// CIs
+const ACL_HANDLER_CI = Web3.utils.keccak256("ACLHandler");
+const CONTRACT_ADDRESS_HANDLER_CI = Web3.utils.keccak256("ContractAddressHandler");
+const BALANCE_CI = Web3.utils.keccak256("balance");
+const ROOT_CI = Web3.utils.keccak256("root");
 
-contract('EtherCollectorTest', function ([root, _, testAccount1, testAccount2]) {
+const ETHER_COLLECTOR_CI = Web3.utils.keccak256("EtherCollector");
+const ETHER_COLLECTOR_STORAGE_CI = Web3.utils.keccak256("EtherCollectorStorage");
 
-    const aclHandlerCI = wweb3.utils.keccak256("ACLHandler");
-    const contractAddressHandlerCI = wweb3.utils.keccak256("ContractAddressHandler");
-    const balance = wweb3.utils.keccak256("balance");
-    const rootCI = wweb3.utils.keccak256("root");
-
-    const etherCollectorCI = wweb3.utils.keccak256("EtherCollector");
-    const etherCollectorStorageCI = wweb3.utils.keccak256("EtherCollectorStorage");
-
-    const testNameSpace1 = wweb3.utils.keccak256("testNameSpace1");
-    const testNameSpace2 = wweb3.utils.keccak256("testNameSpace2");
-
-
-    //SIG
-    const SET_STORAGE_SIG = "0x9137c1a7";
-    const DEPOSIT_SIG = "0xd0e30db0";
-
-    const SET_UINT_SIG = "0xe2a4853a";
-    const GET_UINT_SIG = "0xbd02d0f5";
-    const WITHDRAW_SIG = "0xf3fef3a3";
+//SIG
+const SET_STORAGE_SIG = wweb3.eth.abi.encodeFunctionSignature("setStorage(address)");
+const DEPOSIT_SIG = wweb3.eth.abi.encodeFunctionSignature("deposit()");
+//
+const SET_UINT_SIG = wweb3.eth.abi.encodeFunctionSignature("setUint(bytes32,uint256)");
+const GET_UINT_SIG = wweb3.eth.abi.encodeFunctionSignature("getUint(bytes32)");
+const WITHDRAW_SIG = wweb3.eth.abi.encodeFunctionSignature("withdraw(address,uint256)");
 
 
+contract("EtherCollectorTest", function ([root, _, testAccount1, testAccount2]) {
     before(async function () {
-    });
-
-    beforeEach(async function () {
         this.value = 12345;
 
         this.kernel = await Kernel.new();
         this.aclHandler = await ACLHandler.new(this.kernel.address);
         this.contractAddressHandler = await ContractAddressHandler.new(this.kernel.address);
 
-        this.kernel.registerHandler(aclHandlerCI, this.aclHandler.address);
-        this.kernel.registerHandler(contractAddressHandlerCI, this.contractAddressHandler.address);
-
-        this.kernel.connect(this.aclHandler.address, []);
-        this.kernel.connect(this.contractAddressHandler.address, []);
+        this.kernel.registerHandler(ACL_HANDLER_CI, this.aclHandler.address);
+        this.kernel.registerHandler(
+            CONTRACT_ADDRESS_HANDLER_CI,
+            this.contractAddressHandler.address);
 
         this.etherCollector = await EtherCollector.new(this.kernel.address);
         this.etherCollectorStorage = await EtherCollectorStorage.new(this.kernel.address);
 
-        this.kernel.connect(this.etherCollector.address, [aclHandlerCI, contractAddressHandlerCI]).should.be
-            .fulfilled;
-        this.kernel.connect(this.etherCollectorStorage.address, [aclHandlerCI, contractAddressHandlerCI]).should
-            .be.fulfilled;
+        // kernel connect handers
+        this.kernel.connect(this.aclHandler.address, []);
+        this.kernel.connect(this.contractAddressHandler.address, []);
+
+        this.kernel.connect(
+            this.etherCollector.address,
+            [ACL_HANDLER_CI, CONTRACT_ADDRESS_HANDLER_CI]).should.be.fulfilled;
+        this.kernel.connect(
+            this.etherCollectorStorage.address,
+            [ACL_HANDLER_CI, CONTRACT_ADDRESS_HANDLER_CI]).should.be.fulfilled;
 
         // register contract
-        this.contractAddressHandler.registerContract(rootCI, root).should.be.fulfilled;
-        this.contractAddressHandler.registerContract(etherCollectorCI, this.etherCollector.address).should.be.fulfilled;
-        this.contractAddressHandler.registerContract(etherCollectorStorageCI, this.etherCollectorStorage.address)
-            .should.be.fulfilled;
+        this.contractAddressHandler.registerContract(ROOT_CI, root).should.be.fulfilled;
+        this.contractAddressHandler.registerContract(
+            ETHER_COLLECTOR_CI,
+            this.etherCollector.address).should.be.fulfilled;
+        this.contractAddressHandler.registerContract(
+            ETHER_COLLECTOR_STORAGE_CI,
+            this.etherCollectorStorage.address).should.be.fulfilled;
 
         // give permit for root address call registerOwner and setHandler
-        this.aclHandler.permit(rootCI, etherCollectorCI, SET_STORAGE_SIG).should.be.fulfilled;
-        this.aclHandler.permit(rootCI, etherCollectorCI, DEPOSIT_SIG).should.be.fulfilled;
-        this.aclHandler.permit(rootCI, etherCollectorCI, WITHDRAW_SIG).should.be.fulfilled;
+        this.aclHandler.permit(ROOT_CI, ETHER_COLLECTOR_CI, SET_STORAGE_SIG).should.be.fulfilled;
+        this.aclHandler.permit(ROOT_CI, ETHER_COLLECTOR_CI, DEPOSIT_SIG).should.be.fulfilled;
+        this.aclHandler.permit(ROOT_CI, ETHER_COLLECTOR_CI, WITHDRAW_SIG).should.be.fulfilled;
 
-        this.aclHandler.permit(rootCI, etherCollectorStorageCI, SET_UINT_SIG).should.be.fulfilled;
-        this.aclHandler.permit(rootCI, etherCollectorStorageCI, GET_UINT_SIG).should.be.fulfilled;
+        this.aclHandler.permit(ROOT_CI, ETHER_COLLECTOR_STORAGE_CI, SET_UINT_SIG)
+            .should.be.fulfilled;
+        this.aclHandler.permit(ROOT_CI, ETHER_COLLECTOR_STORAGE_CI, GET_UINT_SIG)
+            .should.be.fulfilled;
+        this.aclHandler.permit(ETHER_COLLECTOR_CI, ETHER_COLLECTOR_STORAGE_CI, SET_UINT_SIG)
+            .should.be.fulfilled;
 
+        this.etherCollector.setStorage(this.etherCollectorStorage.address).should.be.fulfilled;
     });
 
-    describe('EtherCollector basic test', function () {
-        it('should connected', async function () {
-            var result = await this.etherCollector.isConnected.call();
+    describe("EtherCollector basic test", function () {
+        it("should connected", async function () {
+            let result = await this.etherCollector.isConnected.call();
             result.should.be.equal(true);
         });
 
-        it('should register contract success', async function () {
-            var result = await this.etherCollector.CI.call();
-            result.should.be.equal(etherCollectorCI);
+        it("should register contract success", async function () {
+            let result = await this.etherCollector.CI.call();
+            result.should.be.equal(ETHER_COLLECTOR_CI);
         });
-
-        it('should set storage success', async function () {
-            await this.etherCollector.setStorage(this.etherCollectorStorage.address).should.be.fulfilled;
-        });
-
     });
 
-    describe('EtherCollectorStorage basic test', function () {
-        it('should connected', async function () {
-            var result = await this.etherCollectorStorage.isConnected.call();
+    describe("EtherCollectorStorage basic test", function () {
+        it("should connected", async function () {
+            let result = await this.etherCollectorStorage.isConnected.call();
             result.should.be.equal(true);
         });
 
-        it('should register contract success', async function () {
-            var result = await this.etherCollectorStorage.CI.call();
-            result.should.be.equal(etherCollectorStorageCI);
+        it("should register contract success", async function () {
+            let result = await this.etherCollectorStorage.CI.call();
+            result.should.be.equal(ETHER_COLLECTOR_STORAGE_CI);
         });
 
-        it('should set/get uint correctly', async function () {
-            await this.etherCollectorStorage.setUint(balance, this.value).should.be.fulfilled;
-            var result = await this.etherCollectorStorage.getUint.call(balance);
-            result.should.be.bignumber.equal(this.value);
+        it("should set/get uint correctly", async function () {
+            let pre = await this.etherCollectorStorage.getUint.call(BALANCE_CI);
+            await this.etherCollectorStorage.setUint(BALANCE_CI, this.value).should.be.fulfilled;
+            let post = await this.etherCollectorStorage.getUint.call(BALANCE_CI);
+            post.minus(pre).should.be.bignumber.equal(this.value);
         })
     });
 
-    describe('composite test', function () {
-        beforeEach(async function () {
-            await this.etherCollector.setStorage(this.etherCollectorStorage.address).should.be.fulfilled;
-        });
-
-        it('should deposit success', async function () {
-
-            await this.aclHandler.permit(etherCollectorCI, etherCollectorStorageCI, SET_UINT_SIG).should.be.fulfilled;
-
-            //const pre = web3.eth.getBalance(root);
-            await this.etherCollector.deposit({value: this.value}).should.be.fulfilled;
-            //const post = web3.eth.getBalance(root);
-            //pre.mins(pre).should.be.bignumber.equal(value);
-
-            var result = await this.etherCollectorStorage.getUint.call(balance);
-            result.should.be.bignumber.equal(this.value);
-        });
-
-        it('should withdraw success', async function () {
-            await this.aclHandler.permit(etherCollectorCI, etherCollectorStorageCI, SET_UINT_SIG).should.be.fulfilled;
+    describe("composite test", function () {
+        it("should deposit success", async function () {
+            let pre = await this.etherCollectorStorage.getUint.call(BALANCE_CI);
             await this.etherCollector.deposit({value: this.value}).should.be.fulfilled;
 
-            await this.etherCollector.withdraw(testAccount1, this.value - 10000).should.be.fulfilled;
-
-            var result = await this.etherCollectorStorage.getUint.call(balance);
-            result.should.be.bignumber.equal(10000);
-
+            let post = await this.etherCollectorStorage.getUint.call(BALANCE_CI);
+            post.minus(pre).should.be.bignumber.equal(this.value);
         });
 
+        it("should withdraw success", async function () {
+            const withdrawAmount = 10000;
+
+            await this.etherCollector.deposit({value: this.value}).should.be.fulfilled;
+
+            let pre = await this.etherCollectorStorage.getUint.call(BALANCE_CI);
+            await this.etherCollector.withdraw(testAccount1, withdrawAmount).should.be.fulfilled;
+            let post= await this.etherCollectorStorage.getUint.call(BALANCE_CI);
+
+            pre.minus(post).should.be.bignumber.equal(withdrawAmount);
+        });
     });
 
-    describe('branch test', function () {
-        beforeEach(async function () {
-            await this.etherCollector.setStorage(this.etherCollectorStorage.address).should.be.fulfilled;
-        });
-
-        it('should rejected by EVM Throw', async function () {
-            await this.etherCollector.deposit({value: this.value}).should.be.rejectedWith(EVMRevert);
-        });
-
-        it('should rejected withdraw ', async function () {
-            await this.aclHandler.permit(etherCollectorCI, etherCollectorStorageCI, SET_UINT_SIG).should.be.fulfilled;
-            await this.etherCollector.deposit({value: this.value}).should.be.fulfilled;
-
-            await this.etherCollector.withdraw(testAccount1, 1 + this.value).should.be.rejectedWith(EVMRevert);
-        });
-
-        it('should rejected withdraw cause not connected', async function () {
-            await this.kernel.disconnect(this.etherCollector.address, [aclHandlerCI, contractAddressHandlerCI])
-                .should.be.fulfilled;
-            await this.etherCollector.withdraw(testAccount1, this.value).should.be.rejectedWith(EVMRevert);
+    describe("branch test", function () {
+        it("should rejected withdraw", async function () {
+            let currentBalance = await this.etherCollectorStorage.getUint.call(BALANCE_CI);
+            await this.etherCollector.withdraw(testAccount1, 1 + currentBalance)
+                .should.be.rejectedWith(EVMRevert);
         });
     });
 });

--- a/solidity/test/module/tokenCollectorModule.test.js
+++ b/solidity/test/module/tokenCollectorModule.test.js
@@ -1,39 +1,34 @@
-import EVMRevert from 'openzeppelin-solidity/test/helpers/EVMRevert'
-import EVMThrow from 'openzeppelin-solidity/test/helpers/EVMThrow'
+import EVMRevert from "openzeppelin-solidity/test/helpers/EVMRevert"
+import EVMThrow from "openzeppelin-solidity/test/helpers/EVMThrow"
 
-const wweb3 = require('web3')
+const Web3 = require("web3")
+const wweb3 = new Web3();
 const BigNumber = web3.BigNumber;
 
-const should = require('chai')
-    .use(require('chai-as-promised'))
-    .use(require('chai-bignumber')(BigNumber))
+const should = require("chai")
+    .use(require("chai-as-promised")) .use(require("chai-bignumber")(BigNumber))
     .should();
 
-const TokenCollectorModule = artifacts.require('modules/TokenCollectorModule');
-const Token = artifacts.require('mocks/Token');
-const ACLHandler  = artifacts.require('handler/ACLHandler');
-const ContractAddressHandler = artifacts.require('handler/ContractAddressHandler');
-const Kernel = artifacts.require('kernel/Kernel');
+const TokenCollectorModule = artifacts.require("modules/TokenCollectorModule");
+const Token = artifacts.require("mocks/Token");
+const ACLHandler  = artifacts.require("handler/ACLHandler");
+const ContractAddressHandler = artifacts.require("handler/ContractAddressHandler");
+const Kernel = artifacts.require("kernel/Kernel");
 
-contract('TokenCollectorModuleTest', function ([root, _, testAccount1, testAccount2]) {
-    const aclHandlerCI = wweb3.utils.keccak256("ACLHandler");
-    const tokenCollectorModuleCI = wweb3.utils.keccak256("TokenCollectorModule");
+const ACL_HANDLER_CI = Web3.utils.keccak256("ACLHandler");
+const TOKEN_COLLECTOR_MODULE_CI = Web3.utils.keccak256("TokenCollectorModule");
 
-    const testNameSpace1 = wweb3.utils.keccak256("testNameSpace1");
-    const testNameSpace2 = wweb3.utils.keccak256("testNameSpace2");
+const CONTRACT_ADDRESS_HANDLER_CI = Web3.utils.keccak256("ContractAddressHandler");
+const ROOT_CI = Web3.utils.keccak256("root");
 
-    const contractAddressHandlerCI = wweb3.utils.keccak256("ContractAddressHandler");
-    const rootCI = wweb3.utils.keccak256("root");
+const DEPOSIT_SIG = wweb3.eth.abi.encodeFunctionSignature("deposit(address,uint256)");
+const WITHDRAW_SIG = wweb3.eth.abi.encodeFunctionSignature("withdraw(address,address,uint256)");
 
-    //const WITHDRAW_SIG = wweb3.utils.keccak256("withdraw(address,address,uint)");
-    //const DEPOSIT_SIG = wweb3.utils.keccak256("deposit(address,uint)");
-    const WITHDRAW_SIG = "0xd9caed12";
-    const DEPOSIT_SIG = "0x47e7ef24";
+const NULL_ADDRESS = "0x0";
 
+
+contract("TokenCollectorModuleTest", function ([root, _, testAccount]) {
     before(async function () {
-    });
-
-    beforeEach(async function () {
         this.totalSpendMoney = 1000000;
         this.value = 10000;
 
@@ -44,86 +39,87 @@ contract('TokenCollectorModuleTest', function ([root, _, testAccount1, testAccou
         this.tokenCollectorModule = await TokenCollectorModule.new(this.kernel.address);
 
         // register Handler
-        this.kernel.registerHandler(aclHandlerCI, this.aclHandler.address);
-        this.kernel.registerHandler(contractAddressHandlerCI, this.contractAddressHandler.address);
+        this.kernel.registerHandler(ACL_HANDLER_CI, this.aclHandler.address);
+        this.kernel.registerHandler(
+            CONTRACT_ADDRESS_HANDLER_CI,
+            this.contractAddressHandler.address);
 
         // connect
         this.kernel.connect(this.aclHandler.address, []);
         this.kernel.connect(this.contractAddressHandler.address, []);
-        this.kernel.connect(this.tokenCollectorModule.address, [aclHandlerCI, contractAddressHandlerCI])
-            .should.be.fulfilled;
+        this.kernel.connect(
+            this.tokenCollectorModule.address,
+            [ACL_HANDLER_CI, CONTRACT_ADDRESS_HANDLER_CI]).should.be.fulfilled;
 
         // register contract
-        this.contractAddressHandler.registerContract(rootCI, root).should.be.fulfilled;
+        this.contractAddressHandler.registerContract(ROOT_CI, root).should.be.fulfilled;
 
         // give permit for root address call registerOwner and setHandler
-        this.aclHandler.permit(rootCI, tokenCollectorModuleCI, WITHDRAW_SIG).should.be.fulfilled;
-        this.aclHandler.permit(rootCI, tokenCollectorModuleCI, DEPOSIT_SIG).should.be.fulfilled;
+        this.aclHandler.permit(ROOT_CI, TOKEN_COLLECTOR_MODULE_CI, WITHDRAW_SIG)
+            .should.be.fulfilled;
+        this.aclHandler.permit(ROOT_CI, TOKEN_COLLECTOR_MODULE_CI, DEPOSIT_SIG).should.be.fulfilled;
 
-        // give tokenCollectorModule permission to speed root's money
-        this.token.approve(this.tokenCollectorModule.address, this.totalSpendMoney).should.be.fulfilled;
+        // give tokenCollectorModule permission to speed root"s money
+        this.token.approve(this.tokenCollectorModule.address, this.totalSpendMoney)
+            .should.be.fulfilled;
+
+        // some basic test
+        const val = await this.tokenCollectorModule.balanceOf.call(this.token.address);
+        val.should.be.bignumber.equal(0);
     });
 
-    describe('basic test', function () {
-        it('should connected', async function () {
-            var result = await this.tokenCollectorModule.isConnected.call();
+    describe("basic test", function () {
+        it("should connected", async function () {
+            let result = await this.tokenCollectorModule.isConnected.call();
             result.should.be.equal(true);
         });
 
-        it('should register contract success', async function () {
-            var result = await this.tokenCollectorModule.CI.call();
-            result.should.be.equal(tokenCollectorModuleCI);
+        it("should register contract success", async function () {
+            let result = await this.tokenCollectorModule.CI.call();
+            result.should.be.equal(TOKEN_COLLECTOR_MODULE_CI);
         });
 
-        it('should receive correct handler', async function () {
-            var result = await this.tokenCollectorModule.handlers.call(aclHandlerCI);
+        it("should receive correct handler", async function () {
+            let result = await this.tokenCollectorModule.handlers.call(ACL_HANDLER_CI);
             result.should.be.equal(this.aclHandler.address);
-            result = await this.tokenCollectorModule.handlers.call(contractAddressHandlerCI);
+            result = await this.tokenCollectorModule.handlers.call(CONTRACT_ADDRESS_HANDLER_CI);
             result.should.be.equal(this.contractAddressHandler.address);
         });
 
-        it('should receive correct kernel', async function () {
-            var result = await this.tokenCollectorModule.kernel.call();
+        it("should receive correct kernel", async function () {
+            let result = await this.tokenCollectorModule.kernel.call();
             result.should.be.equal(this.kernel.address);
         });
 
-        it('should receive status connected', async function () {
-            var result = await this.tokenCollectorModule.status.call();
+        it("should receive status connected", async function () {
+            let result = await this.tokenCollectorModule.status.call();
             result.should.be.bignumber.equal(1);
         });
-
-        it("should disconnect", async function () {
-            await this.kernel.disconnect(this.tokenCollectorModule.address, [aclHandlerCI, contractAddressHandlerCI])
-                .should.be.fulfilled;
-            var result = await this.tokenCollectorModule.isConnected.call();
-            result.should.be.equal(false);
-        });
-
     });
 
-    describe('branch test', function () {
-
-        it('should rejected cause invalid token address', async function () {
-            this.tokenCollectorModule.balanceOf("0x0").should.be.rejectedWith(EVMRevert);
-            this.tokenCollectorModule.withdraw("0x0", root, 0).should.be.rejectedWith(EVMRevert);
-            this.tokenCollectorModule.withdraw(this.token.address, "0x0", 0).should.be.rejectedWith(EVMRevert);
-            this.tokenCollectorModule.deposit("0x0", 0).should.be.rejectedWith(EVMRevert);
+    describe("branch test", function () {
+        it("should rejected cause invalid token address", async function () {
+            this.tokenCollectorModule.balanceOf(NULL_ADDRESS).should.be.rejectedWith(EVMRevert);
+            this.tokenCollectorModule.withdraw(NULL_ADDRESS, root, 0)
+                .should.be.rejectedWith(EVMRevert);
+            this.tokenCollectorModule.withdraw(this.token.address, NULL_ADDRESS, 0)
+                .should.be.rejectedWith(EVMRevert);
+            this.tokenCollectorModule.deposit(NULL_ADDRESS, 0).should.be.rejectedWith(EVMRevert);
         });
 
-        it('should rejected when withdraw value over balance', async function () {
-            this.tokenCollectorModule.withdraw(this.token.address, root, 1).should.be.rejectedWith(EVMRevert);
+        it("should rejected when withdraw value over balance", async function () {
+            let balance = await this.tokenCollectorModule.balanceOf.call(this.token.address);
+            this.tokenCollectorModule.withdraw(this.token.address, root, balance + 1)
+                .should.be.rejectedWith(EVMRevert);
         });
     });
 
-    describe('basic functional test', function () {
-        it('should receive balance zero', async function () {
-            const val = await this.tokenCollectorModule.balanceOf.call(this.token.address);
-            val.should.be.bignumber.equal(0);
-        });
+    describe("basic functional test", function () {
+        it("should approve success", async function () {
+            const { logs } = await this.token.approve(
+                this.tokenCollectorModule.address,
+                this.totalSpendMoney).should.be.fulfilled;
 
-        it('should approve success', async function () {
-            const { logs } = await this.token.approve(this.tokenCollectorModule.address, this.totalSpendMoney)
-                .should.be.fulfilled;
             const event = logs.find(e => e.event === "Approval");
             should.exist(event);
             event.args.owner.should.be.equal(root);
@@ -131,44 +127,30 @@ contract('TokenCollectorModuleTest', function ([root, _, testAccount1, testAccou
             event.args.value.should.be.bignumber.equal(this.totalSpendMoney);
         });
 
-        it('should deposit success', async function () {
-            const event = this.token.Transfer();
-
+        it("should deposit success", async function () {
             const pre = await this.token.balanceOf.call(root);
             await this.tokenCollectorModule.deposit(this.token.address, this.value)
                 .should.be.fulfilled;
             const post = await this.token.balanceOf.call(root);
             pre.minus(post).should.be.bignumber.equal(this.value);
-
-            await event.watch((err, res) => {
-                res.args.from.should.be.equal(root);
-                res.args.to.should.be.equal(this.tokenCollectorModule.address);
-                res.args.value.should.be.bignumber.equal(this.value);
-            })
         });
 
-        it('should withdraw success', async function () {
+        it("should withdraw success", async function () {
             const withdrawAmount = 200;
 
-            const pre = await this.token.balanceOf.call(testAccount1);
+            const pre = await this.token.balanceOf.call(testAccount);
             await this.tokenCollectorModule.deposit(this.token.address, this.value)
                 .should.be.fulfilled;
+            const storeBalance = await this.tokenCollectorModule.balanceOf.call(this.token.address);
 
-            const event = this.token.Transfer();
-            await this.tokenCollectorModule.withdraw(this.token.address, testAccount1, withdrawAmount)
-                .should.be.fulfilled;
-            const post = await this.token.balanceOf.call(testAccount1);
+            await this.tokenCollectorModule.withdraw(
+                this.token.address,
+                testAccount, withdrawAmount) .should.be.fulfilled;
+            const post = await this.token.balanceOf.call(testAccount);
             post.minus(pre).should.be.bignumber.equal(withdrawAmount);
 
             const val = await this.tokenCollectorModule.balanceOf.call(this.token.address);
-            val.should.be.bignumber.equal(this.value - withdrawAmount);
-
-            await event.watch((err, res) => {
-                res.args.from.should.be.equal(this.tokenCollectorModule.address);
-                res.args.to.should.be.equal(testAccount1);
-                res.args.value.should.be.bignumber.equal(withdrawAmount);
-            })
+            val.should.be.bignumber.equal(storeBalance - withdrawAmount);
         });
     });
-
 });


### PR DESCRIPTION
Simplify test cases for `etherCollector` and `tokenCollector`.  Move instance creation from `beforeEach` to `before`. Keep coverage 100%. 
