### PR TITLE
Fix #169 Migration function for all existing modules

### DIFF
--- a/solidity/config/configuation.js
+++ b/solidity/config/configuation.js
@@ -1,0 +1,331 @@
+'use strict'
+
+const Constant = require('../config/config.js')
+
+const run = exports.run = async (instances, [root], artifacts) => {
+  /* ------- receive Constant -------- */
+  const _constants = Constant.default(artifacts)
+
+  /* ------- receive objects  -------- */
+  const Kernel = _constants.Kernel
+  const ACLHandler = _constants.ACLHandler
+  const ContractAddressHandler = _constants.ContractAddressHandler
+  const RefundManager = _constants.RefundManager
+  const ProjectController = _constants.ProjectController
+  const MilestoneController = _constants.MilestoneController
+  const EtherCollector = _constants.EtherCollector
+  const TokenCollector = _constants.TokenCollector
+  const TokenSale = _constants.TokenSale
+  const Storage = _constants.Storage
+
+  /* ------- receive instances  -------- */
+  // Token
+  const token = instances.token
+  const vetXToken = instances.vetXToken
+
+  // Kernel
+  const kernel = instances.kernel
+
+  // Handlers
+  const aclHandler = instances.aclHandler
+  const contractAddressHandler = instances.contractAddressHandler
+
+  // Refund Manager
+  const refundManager = instances.refundManager
+  const refundManagerStorage = instances.refundManagerStorage
+
+  // Project Controller
+  const projectController = instances.projectController
+  const projectControllerStorage = instances.projectControllerStorage
+
+  // Milestone Controller
+  const milestoneController = instances.milestoneController
+  const milestoneControllerStorage = instances.milestoneControllerStorage
+
+  // Ether Collector
+  const etherCollector = instances.etherCollector
+  const etherCollectorStorage = instances.etherCollectorStorage
+
+  // Token Collector
+  const tokenCollector = instances.tokenCollector
+
+  // Token Sale
+  const tokenSale = instances.tokenSale
+
+  /* ---------------------Kernel Register Handlers----------------------------- */
+  // ACLHandler
+  await kernel.registerHandler(ACLHandler.CI, aclHandler.address)
+
+  // ContractAddressHandler
+  await kernel.registerHandler(ContractAddressHandler.CI,
+    contractAddressHandler.address)
+
+  /* ---------------------Kernel Connect Handlers & Modules---- --------------- */
+  /**
+   * Kernel Connect handlers
+   */
+  // AclHandler
+  await kernel.connect(aclHandler.address, [])
+
+  // ContractAddressHandler
+  await kernel.connect(contractAddressHandler.address, [])
+
+  /**
+   * Kernel Connect managers
+   */
+  // Refund Manager
+  await kernel.connect(
+    refundManager.address,
+    [ACLHandler.CI, ContractAddressHandler.CI])
+  await kernel.connect(
+    refundManagerStorage.address,
+    [ACLHandler.CI, ContractAddressHandler.CI])
+
+  /**
+   * Kernel Connect controllers
+   */
+  // ProjectController
+  await kernel.connect(
+    projectController.address,
+    [ACLHandler.CI, ContractAddressHandler.CI])
+  await kernel.connect(
+    projectControllerStorage.address,
+    [ACLHandler.CI, ContractAddressHandler.CI])
+
+  // MilestoneController
+  await kernel.connect(
+    milestoneController.address,
+    [ACLHandler.CI, ContractAddressHandler.CI])
+  await kernel.connect(
+    milestoneControllerStorage.address,
+    [ACLHandler.CI, ContractAddressHandler.CI])
+
+  // EtherCollector
+  await kernel.connect(
+    etherCollector.address,
+    [ACLHandler.CI, ContractAddressHandler.CI])
+  await kernel.connect(
+    etherCollectorStorage.address,
+    [ACLHandler.CI, ContractAddressHandler.CI])
+
+  // TokenCollector
+  await kernel.connect(
+    tokenCollector.address,
+    [ACLHandler.CI, ContractAddressHandler.CI])
+
+  // TokenSale
+  await kernel.connect(
+    tokenSale.address,
+    [ACLHandler.CI, ContractAddressHandler.CI])
+
+  /* ---------------ContractAddressHandler Registers Contracts--------------- */
+  /**
+   * ContractAddressHandler Register Root
+   */
+  await contractAddressHandler.registerContract(Kernel.RootCI, root)
+
+  /**
+   * ContractAddressHandler Register managers
+   */
+  // Refund Manager
+  await contractAddressHandler.registerContract(
+    RefundManager.CI,
+    refundManager.address)
+  await contractAddressHandler.registerContract(
+    RefundManager.Storage.CI,
+    refundManagerStorage.address)
+
+  /**
+   * ContractAddressHandler Register controllers
+   */
+  // Project Controller
+  await contractAddressHandler.registerContract(
+    ProjectController.CI,
+    projectController.address)
+  await contractAddressHandler.registerContract(
+    ProjectController.Storage.CI,
+    projectControllerStorage.address)
+
+  // Milestone Controller
+  await contractAddressHandler.registerContract(
+    MilestoneController.CI,
+    milestoneController.address)
+  await contractAddressHandler.registerContract(
+    MilestoneController.Storage.CI,
+    milestoneControllerStorage.address)
+
+  // Ether Collector
+  await contractAddressHandler.registerContract(
+    EtherCollector.CI,
+    etherCollector.address)
+  await contractAddressHandler.registerContract(
+    EtherCollector.Storage.CI,
+    etherCollectorStorage.address)
+
+  // Token Collector
+  await contractAddressHandler.registerContract(
+    TokenCollector.CI,
+    tokenCollector.address)
+
+  // Token Sale
+  await contractAddressHandler.registerContract(
+    TokenSale.CI,
+    tokenSale.address)
+
+  /* -----------------------ACLHandler Grants permit ------------------------ */
+  /**
+   * Grant permits to Root
+   */
+  // Destination: Refund Manager
+  await aclHandler.permit(
+    Kernel.RootCI,
+    RefundManager.CI,
+    [RefundManager.Sig.SetStorage])
+
+  // Destination: Project Controller
+  await aclHandler.permit(
+    Kernel.RootCI,
+    ProjectController.CI,
+    [
+      ProjectController.Sig.RegisterProject,
+      ProjectController.Sig.UnregisterProject,
+      ProjectController.Sig.SetState,
+      ProjectController.Sig.SetStorage,
+      ProjectController.Sig.SetTokenAddress
+    ])
+  await aclHandler.permit(
+    Kernel.RootCI,
+    ProjectController.Storage.CI,
+    [Storage.Sig.SetUint, Storage.Sig.SetAddress, Storage.Sig.SetBytes32])
+
+  // Destination: Milestone Controller
+  await aclHandler.permit(
+    Kernel.RootCI,
+    MilestoneController.CI,
+    [MilestoneController.Sig.SetStorage])
+  await aclHandler.permit(
+    Kernel.RootCI,
+    MilestoneController.Storage.CI,
+    [Storage.Sig.SetUint, Storage.Sig.SetArray])
+
+  // Destination: Token Collector
+  await aclHandler.permit(
+    Kernel.RootCI,
+    TokenCollector.CI,
+    [TokenCollector.Sig.Withdraw, TokenCollector.Sig.Deposit])
+
+  // Destination: Ether Collector
+  await aclHandler.permit(
+    Kernel.RootCI,
+    EtherCollector.CI,
+    [
+      EtherCollector.Sig.SetStorage,
+      EtherCollector.Sig.Deposit,
+      EtherCollector.Sig.Withdraw
+    ])
+  await aclHandler.permit(
+    Kernel.RootCI,
+    EtherCollector.Storage.CI,
+    [Storage.Sig.SetUint])
+
+  /**
+   * Grant permits to managers
+   */
+  // Source: Refund Manager
+  // Destination: Refund Manager Storage
+  await aclHandler.permit(
+    RefundManager.CI,
+    RefundManager.Storage.CI,
+    [Storage.Sig.SetUint])
+  // Destination: Token Collector
+  await aclHandler.permit(
+    RefundManager.CI,
+    TokenCollector.CI,
+    [TokenCollector.Sig.Deposit])
+  // Destination: Token Collector
+  await aclHandler.permit(
+    RefundManager.CI,
+    EtherCollector.CI,
+    [EtherCollector.Sig.Withdraw])
+
+  /**
+   * Grant permits to controllers
+   */
+  // Source: Project Controller
+  // Destination: Project Controller Storage
+  await aclHandler.permit(
+    ProjectController.CI,
+    ProjectController.Storage.CI,
+    [Storage.Sig.SetUint, Storage.Sig.SetAddress, Storage.Sig.SetBytes32])
+
+  // Source: Milestone Controller
+  // Destination: Milestone Controller Storage
+  await aclHandler.permit(
+    MilestoneController.CI,
+    MilestoneController.Storage.CI,
+    [Storage.Sig.SetUint, Storage.Sig.SetArray])
+
+  // Source: Ether Collector
+  // Destination: Ether Collector Storage
+  await aclHandler.permit(
+    EtherCollector.CI,
+    EtherCollector.Storage.CI,
+    [Storage.Sig.SetUint])
+
+  // Source: Token Sale
+  // Destination: Token Controller
+  await aclHandler.permit(
+    TokenSale.CI,
+    TokenCollector.CI,
+    [TokenCollector.Sig.Withdraw])
+
+  /* ------------------------Set Storage------------------------- */
+  /**
+   * Set Storage for managers
+   */
+  // Refund Manager
+  await refundManager.setStorage(refundManagerStorage.address)
+
+  /**
+   * Set Storage for controllers
+   */
+  // Project Controller
+  await projectController.setStorage(projectControllerStorage.address)
+
+  // Milestone Controller
+  await milestoneController.setStorage(milestoneControllerStorage.address)
+
+  // Ether Collector
+  await etherCollector.setStorage(etherCollectorStorage.address)
+
+  /* -----------------------Managers Connected to Controllers---------------- */
+  // Refund Manager
+  contractAddressHandler.connect(
+    refundManager.address,
+    [
+      ProjectController.CI,
+      MilestoneController.CI,
+      TokenSale.CI,
+      TokenCollector.CI,
+      EtherCollector.CI
+    ])
+
+  /* -----------------------Return------------------------------------------- */
+  return {
+    token,
+    vetXToken,
+    kernel,
+    aclHandler,
+    contractAddressHandler,
+    refundManager,
+    refundManagerStorage,
+    projectController,
+    projectControllerStorage,
+    milestoneController,
+    milestoneControllerStorage,
+    etherCollector,
+    etherCollectorStorage,
+    tokenCollector,
+    tokenSale
+  }
+}

--- a/solidity/contracts/modules/managers/refund_manager/RefundManagerStorage.sol
+++ b/solidity/contracts/modules/managers/refund_manager/RefundManagerStorage.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.24;
 
 import '../../storage/Storage.sol';
 

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -29,6 +29,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "chai-bignumber": "^2.0.2",
+    "standard": "^11.0.1",
     "truffle-hdwallet-provider": "0.0.4"
   },
   "standard": {

--- a/solidity/test/shared.js
+++ b/solidity/test/shared.js
@@ -8,352 +8,72 @@ import {
   MilestoneController,
   EtherCollector,
   TokenCollector,
-  TokenSale,
-  Storage} from "./constants.js";
+  TokenSale} from './constants.js'
 
-const run = exports.run = async([root]) => {
-  /*---------------------Deploy Contracts---------------------------------*/
+const Configuation = require('../config/configuation.js')
+
+const run = exports.run = async (accounts) => {
+  let instances = {}
+
+  /* ---------------------Deploy Contracts--------------------------------- */
   /**
    * deploy token
    */
-  const token = await Token.Self.new();
-
+  instances.token = await Token.Self.new()
 
   /**
    * deploy kernel
    */
-  const kernel = await Kernel.Self.new();
-
+  instances.kernel = await Kernel.Self.new()
 
   /**
    * deploy handlers
    */
   // ACLHandler
-  const aclHandler = await ACLHandler.Self.new(kernel.address);
+  instances.aclHandler = await ACLHandler.Self.new(instances.kernel.address)
 
   // ContractAddressHandler
-  const contractAddressHandler = await ContractAddressHandler.Self.new(
-    kernel.address);
-
+  instances.contractAddressHandler = await ContractAddressHandler.Self.new(
+    instances.kernel.address)
 
   /**
    * deploy controllers
    */
   // Refund Manager
-  const refundManager = await RefundManager.Self.new(kernel.address);
-  const refundManagerStorage = await RefundManager.Storage
-    .Self.new(kernel.address);
-
+  instances.refundManager = await RefundManager.Self.new(
+    instances.kernel.address)
+  instances.refundManagerStorage = await RefundManager.Storage.Self.new(
+    instances.kernel.address)
 
   /**
    * deploy controllers
    */
   // Project Controller
-  const projectController = await ProjectController.Self.new(kernel.address);
-  const projectControllerStorage = await ProjectController.Storage.Self.new(
-    kernel.address);
+  instances.projectController = await ProjectController.Self.new(
+    instances.kernel.address)
+  instances.projectControllerStorage = await ProjectController.Storage.Self.new(
+    instances.kernel.address)
 
   // Milestone Controller
-  const milestoneController = await MilestoneController.Self.new(
-    kernel.address);
-  const milestoneControllerStorage = await MilestoneController.Storage.Self.new(
-    kernel.address);
+  instances.milestoneController = await MilestoneController.Self.new(
+    instances.kernel.address)
+  instances.milestoneControllerStorage =
+    await MilestoneController.Storage.Self.new(instances.kernel.address)
 
   // Ether Collector
-  const etherCollector = await EtherCollector.Self.new(kernel.address);
-  const etherCollectorStorage = await EtherCollector.Storage
-    .Self.new(kernel.address);
+  instances.etherCollector = await EtherCollector.Self.new(
+    instances.kernel.address)
+  instances.etherCollectorStorage = await EtherCollector.Storage.Self.new(
+    instances.kernel.address)
 
   // Token Collector
-  const tokenCollector = await TokenCollector.Self.new(kernel.address);
+  instances.tokenCollector = await TokenCollector.Self.new(
+    instances.kernel.address)
 
   // Token Sale
-  const tokenSale = await TokenSale.Self.new(kernel.address);
+  instances.tokenSale = await TokenSale.Self.new(instances.kernel.address)
 
+  const instanceObjects = await Configuation.run(instances, accounts, artifacts)
 
-  /*---------------------Kernel Register Handlers-----------------------------*/
-  // ACLHandler
-  await kernel.registerHandler(ACLHandler.CI, aclHandler.address);
-
-  // ContractAddressHandler
-  await kernel.registerHandler(ContractAddressHandler.CI,
-    contractAddressHandler.address);
-
-
-  /*---------------------Kernel Connect Handlers & Modules---- ---------------*/
-  /**
-   * Kernel Connect handlers
-   */
-  // AclHandler
-  await kernel.connect(aclHandler.address, []);
-
-  // ContractAddressHandler
-  await kernel.connect(contractAddressHandler.address, []);
-
-
-  /**
-   * Kernel Connect managers
-   */
-  // Refund Manager
-  await kernel.connect(
-    refundManager.address,
-    [ACLHandler.CI, ContractAddressHandler.CI]);
-  await kernel.connect(
-    refundManagerStorage.address,
-    [ACLHandler.CI, ContractAddressHandler.CI]);
-
-  /**
-   * Kernel Connect controllers
-   */
-  // ProjectController
-  await kernel.connect(
-    projectController.address,
-    [ACLHandler.CI, ContractAddressHandler.CI]);
-  await kernel.connect(
-    projectControllerStorage.address,
-    [ACLHandler.CI, ContractAddressHandler.CI]);
-
-  // MilestoneController
-  await kernel.connect(
-    milestoneController.address,
-    [ACLHandler.CI, ContractAddressHandler.CI]);
-  await kernel.connect(
-    milestoneControllerStorage.address,
-    [ACLHandler.CI, ContractAddressHandler.CI]);
-
-  // EtherCollector
-  await kernel.connect(
-    etherCollector.address,
-    [ACLHandler.CI, ContractAddressHandler.CI]);
-  await kernel.connect(
-    etherCollectorStorage.address,
-    [ACLHandler.CI, ContractAddressHandler.CI]);
-
-  // TokenCollector
-  await kernel.connect(
-    tokenCollector.address,
-    [ACLHandler.CI, ContractAddressHandler.CI]);
-
-  // TokenSale
-  await kernel.connect(
-    tokenSale.address,
-    [ACLHandler.CI, ContractAddressHandler.CI]);
-
-
-  /*----------------ContractAddressHandler Registers Contracts----------------*/
-  /**
-   * ContractAddressHandler Register Root
-   */
-  await contractAddressHandler.registerContract(Kernel.RootCI, root);
-
-  /**
-   * ContractAddressHandler Register managers
-   */
-  // Refund Manager
-  await contractAddressHandler.registerContract(
-    RefundManager.CI,
-    refundManager.address);
-  await contractAddressHandler.registerContract(
-    RefundManager.Storage.CI,
-    refundManagerStorage.address);
-
-  /**
-   * ContractAddressHandler Register controllers
-   */
-  // Project Controller
-  await contractAddressHandler.registerContract(
-    ProjectController.CI,
-    projectController.address);
-  await contractAddressHandler.registerContract(
-    ProjectController.Storage.CI,
-    projectControllerStorage.address);
-
-  // Milestone Controller
-  await contractAddressHandler.registerContract(
-    MilestoneController.CI,
-    milestoneController.address);
-  await contractAddressHandler.registerContract(
-    MilestoneController.Storage.CI,
-    milestoneControllerStorage.address);
-
-  // Ether Collector
-  await contractAddressHandler.registerContract(
-    EtherCollector.CI,
-    etherCollector.address);
-  await contractAddressHandler.registerContract(
-    EtherCollector.Storage.CI,
-    etherCollectorStorage.address);
-
-  // Token Collector
-  await contractAddressHandler.registerContract(
-    TokenCollector.CI,
-    tokenCollector.address);
-
-  // Token Sale
-  await contractAddressHandler.registerContract(
-    TokenSale.CI,
-    tokenSale.address);
-
-
-  /*------------------------ACLHandler Grants permit -------------------------*/
-  /**
-   * Grant permits to Root
-   */
-  // Destination: Refund Manager
-  await aclHandler.permit(
-    Kernel.RootCI,
-    RefundManager.CI,
-    [RefundManager.Sig.SetStorage]);
-
-  // Destination: Project Controller
-  await aclHandler.permit(
-    Kernel.RootCI,
-    ProjectController.CI,
-    [
-      ProjectController.Sig.RegisterProject,
-      ProjectController.Sig.UnregisterProject,
-      ProjectController.Sig.SetState,
-      ProjectController.Sig.SetStorage,
-      ProjectController.Sig.SetTokenAddress
-    ]);
-  await aclHandler.permit(
-    Kernel.RootCI,
-    ProjectController.Storage.CI,
-    [Storage.Sig.SetUint, Storage.Sig.SetAddress, Storage.Sig.SetBytes32]);
-
-  // Destination: Milestone Controller
-  await aclHandler.permit(
-    Kernel.RootCI,
-    MilestoneController.CI,
-    [MilestoneController.Sig.SetStorage]);
-  await aclHandler.permit(
-    Kernel.RootCI,
-    MilestoneController.Storage.CI,
-    [Storage.Sig.SetUint, Storage.Sig.SetArray]);
-
-  // Destination: Token Collector
-  await aclHandler.permit(
-    Kernel.RootCI,
-    TokenCollector.CI,
-    [TokenCollector.Sig.Withdraw, TokenCollector.Sig.Deposit]);
-
-  // Destination: Ether Collector
-  await aclHandler.permit(
-    Kernel.RootCI,
-    EtherCollector.CI,
-    [
-      EtherCollector.Sig.SetStorage,
-      EtherCollector.Sig.Deposit,
-      EtherCollector.Sig.Withdraw
-    ]);
-  await aclHandler.permit(
-    Kernel.RootCI,
-    EtherCollector.Storage.CI,
-    [Storage.Sig.SetUint]);
-
-
-  /**
-   * Grant permits to managers
-   */
-  // Source: Refund Manager
-  // Destination: Refund Manager Storage
-  await aclHandler.permit(
-    RefundManager.CI,
-    RefundManager.Storage.CI,
-    [Storage.Sig.SetUint]);
-  // Destination: Token Collector
-  await aclHandler.permit(
-    RefundManager.CI,
-    TokenCollector.CI,
-    [TokenCollector.Sig.Deposit]);
-  // Destination: Token Collector
-  await aclHandler.permit(
-    RefundManager.CI,
-    EtherCollector.CI,
-    [EtherCollector.Sig.Withdraw]);
-
-
-  /**
-   * Grant permits to controllers
-   */
-  // Source: Project Controller
-  // Destination: Project Controller Storage
-  await aclHandler.permit(
-    ProjectController.CI,
-    ProjectController.Storage.CI,
-    [Storage.Sig.SetUint, Storage.Sig.SetAddress, Storage.Sig.SetBytes32]);
-
-  // Source: Milestone Controller
-  // Destination: Milestone Controller Storage
-  await aclHandler.permit(
-    MilestoneController.CI,
-    MilestoneController.Storage.CI,
-    [Storage.Sig.SetUint, Storage.Sig.SetArray]);
-
-  // Source: Ether Collector
-  // Destination: Ether Collector Storage
-  await aclHandler.permit(
-    EtherCollector.CI,
-    EtherCollector.Storage.CI,
-    [Storage.Sig.SetUint]);
-
-  // Source: Token Sale
-  // Destination: Token Controller
-  await aclHandler.permit(
-    TokenSale.CI,
-    TokenCollector.CI,
-    [TokenCollector.Sig.Withdraw]);
-
-
-  /*------------------------Set Storage-------------------------*/
-  /**
-   * Set Storage for managers
-   */
-  // Refund Manager
-  await refundManager.setStorage(refundManagerStorage.address);
-
-
-  /**
-   * Set Storage for controllers
-   */
-  // Project Controller
-  await projectController.setStorage(projectControllerStorage.address);
-
-  // Milestone Controller
-  await milestoneController.setStorage(milestoneControllerStorage.address);
-
-  // Ether Collector
-  await etherCollector.setStorage(etherCollectorStorage.address);
-
-
-  /*------------------------Managers Connected to Controllers-----------------*/
-  // Refund Manager
-  contractAddressHandler.connect(
-    refundManager.address,
-    [
-      ProjectController.CI,
-      MilestoneController.CI,
-      TokenSale.CI,
-      TokenCollector.CI,
-      EtherCollector.CI
-    ]);
-
-
-  /*------------------------Return--------------------------------------------*/
-  return {
-    token,
-    kernel,
-    aclHandler,
-    contractAddressHandler,
-    refundManager,
-    refundManagerStorage,
-    projectController,
-    projectControllerStorage,
-    milestoneController,
-    milestoneControllerStorage,
-    etherCollector,
-    etherCollectorStorage,
-    tokenCollector,
-    tokenSale
-  };
-};
+  return instanceObjects
+}

--- a/solidity/truffle.js
+++ b/solidity/truffle.js
@@ -1,61 +1,61 @@
 // babel does not transpile js in node_modules, we need to ignore them
-require("babel-register")({
-    ignore: /node_modules\/(?!openzeppelin-solidity\/test\/helpers)/
+require('babel-register')({
+  ignore: /node_modules\/(?!openzeppelin-solidity\/test\/helpers)/
 })
-require("babel-polyfill");
-var Web3 = require("web3");
+require('babel-polyfill')
+var Web3 = require('web3')
 
-const HDWalletProvider = require("truffle-hdwallet-provider");
-const fs = require("fs");
-let mnemonic = ""
+const HDWalletProvider = require('truffle-hdwallet-provider')
+const fs = require('fs')
+let mnemonic = ''
 
-if (fs.existsSync("mnemonic.txt")) {
-    mnemonic = fs.readFileSync("mnemonic.txt").toString().split("\n")[0]
+if (fs.existsSync('mnemonic.txt')) {
+  mnemonic = fs.readFileSync('mnemonic.txt').toString().split('\n')[0]
 }
 
 module.exports = {
-    // See <http://truffleframework.com/docs/advanced/configuration>
-    // for more about customizing your Truffle configuration!
-    networks: {
-        development: {
-            host: "127.0.0.1",
-            port: 8545,
-            network_id: "*", // Match any network id
-            gas: 6000000,
-            //provider: new HDWalletProvider(mnemonic, "http://localhost:8545",0,5) // <-- Comment this line when using solidity-coverage
-        },
-        testing: {
-            host: "localhost",
-            port: 8545,
-            network_id: "*", // Match any network id
-            gas: 6000000,
-        },
-        rinkeby: {
-            provider: new HDWalletProvider(
-              mnemonic, "https://rinkeby.infura.io/UIovb3o3e1Q0SRHdLaTZ"),
-            network_id: "*",
-            gas: 6000000,
-            gasPrice: 2000000000
-        },
-        mainnet: {
-            provider: new HDWalletProvider(
-              mnemonic, "https://mainnet.infura.io/UIovb3o3e1Q0SRHdLaTZ"),
-            network_id: "1",
-            gas: 7000000,
-            gasPrice: 10000000000
-        },
-        coverage: {
-            host: "127.0.0.1",
-            network_id: "*",
-            port: 8555,         // <-- If you change this, also set the port option in .solcover.js.
-            gas: 0xfffffffffff, // <-- Use this high gas value
-            gasPrice: 0x01      // <-- Use this low gas price
-        }
+  // See <http://truffleframework.com/docs/advanced/configuration>
+  // for more about customizing your Truffle configuration!
+  networks: {
+    development: {
+      host: '127.0.0.1',
+      port: 8545,
+      network_id: '*', // Match any network id
+      gas: 6000000
+      // provider: new HDWalletProvider(mnemonic, "http://localhost:8545",0,5) // <-- Comment this line when using solidity-coverage
     },
-    mocha: {
-        reporter: "eth-gas-reporter",
-        reporterOptions: {
-            currency: "USD"
-        }
+    testing: {
+      host: 'localhost',
+      port: 8545,
+      network_id: '*', // Match any network id
+      gas: 6000000
+    },
+    rinkeby: {
+      provider: new HDWalletProvider(
+        mnemonic, 'https://rinkeby.infura.io/UIovb3o3e1Q0SRHdLaTZ'),
+      network_id: '*',
+      gas: 6000000,
+      gasPrice: 2000000000
+    },
+    mainnet: {
+      provider: new HDWalletProvider(
+        mnemonic, 'https://mainnet.infura.io/UIovb3o3e1Q0SRHdLaTZ'),
+      network_id: '1',
+      gas: 7000000,
+      gasPrice: 10000000000
+    },
+    coverage: {
+      host: '127.0.0.1',
+      network_id: '*',
+      port: 8555, // <-- If you change this, also set the port option in .solcover.js.
+      gas: 0xfffffffffff, // <-- Use this high gas value
+      gasPrice: 0x01 // <-- Use this low gas price
     }
-};
+  },
+  mocha: {
+    reporter: 'eth-gas-reporter',
+    reporterOptions: {
+      currency: 'USD'
+    }
+  }
+}


### PR DESCRIPTION
- split `shared.js` to `shared.js` and `configuation.js`, make full use of common code in shared.
In migration: after deploy contacts, send contacts instances to `configuation.js` to initial  configuration (eg, token connect, register, permit).
- change the solidity version of `RefundManagerStorage` from 0.4.0 to 0.4.24.
- Fix style for some file to Javascript Standard (remove `;` end of line,  using `'` instead of `"`).