### PR TITLE
Fix #276 Provide view function getRefundInfo

### DIFF
--- a/solidity/contracts/modules/managers/refund_manager/RefundManager.sol
+++ b/solidity/contracts/modules/managers/refund_manager/RefundManager.sol
@@ -127,6 +127,37 @@ contract RefundManager is Manager {
         );
     }
 
+    /*
+     * get the refund info for the given milestone 
+     *
+     * @param namespace namespace of the project
+     * @param milestoneId id of a milestone
+     */
+    function getRefundInfo(bytes32 namespace, uint milestoneId) 
+        external 
+        view
+        returns (bool, uint, uint)
+    {
+        bytes32 ethAmountKey = keccak256(abi.encodePacked(
+            namespace, 
+            milestoneId, 
+            msg.sender, 
+            ETH_AMOUNT));
+        bytes32 availableTimeKey = keccak256(abi.encodePacked(
+            namespace, 
+            milestoneId, 
+            msg.sender, 
+            AVAILABLE_TIME));
+
+        uint availableTime = refundManagerStorage.getUint(availableTimeKey);
+        uint ethRefund = refundManagerStorage.getUint(ethAmountKey);
+        bool canWithdraw = availableTime != 0 && 
+            availableTime <= now &&
+            ethRefund > 0;
+
+        return (canWithdraw, ethRefund, availableTime);
+    }
+
     function setStorage(address store) public connected {
         super.setStorage(store);
         refundManagerStorage = RefundManagerStorage(store);

--- a/solidity/test/modules/manager/refundManager.js
+++ b/solidity/test/modules/manager/refundManager.js
@@ -109,6 +109,10 @@ contract('RefundManagerTest', function (accounts) {
       await milestoneController.startRefundStage(ADVANCE_PROJECT_CI, FIRST_MILESTONE_ID)
         .should.be.fulfilled
 
+      const refundInfoBeforeRefund = await refundManager.getRefundInfo(
+        ADVANCE_PROJECT_CI, FIRST_MILESTONE_ID).should.be.fulfilled
+      refundInfoBeforeRefund[0].should.be.equal(false)
+
       const { logs } = await refundManager.refund(
         ADVANCE_PROJECT_CI, FIRST_MILESTONE_ID, refundValue).should.be.fulfilled
       const event = logs.find(e => e.event === 'Refund')
@@ -167,6 +171,11 @@ contract('RefundManagerTest', function (accounts) {
       await refundManager.refund(ADVANCE_PROJECT_CI, FIRST_MILESTONE_ID, refundValue)
         .should.be.fulfilled
 
+      const refundInfoJustAfterRefund = await refundManager.getRefundInfo(
+        ADVANCE_PROJECT_CI, FIRST_MILESTONE_ID).should.be.fulfilled
+      refundInfoJustAfterRefund[0].should.be.equal(false)
+      refundInfoJustAfterRefund[1].should.be.bignumber.equal(refundValue / RATE)
+
       // withdraw
       await refundManager.withdraw(ADVANCE_PROJECT_CI, FIRST_MILESTONE_ID)
         .should.be.rejectedWith(Error.EVMRevert)
@@ -174,6 +183,11 @@ contract('RefundManagerTest', function (accounts) {
         .should.be.rejectedWith(Error.EVMRevert)
       await TimeSetter.increaseTimeTo(
         TimeSetter.latestTime() + TimeSetter.OneMonth)
+
+      const refundInfoOneMonthAfterRefund = await refundManager.getRefundInfo(
+        ADVANCE_PROJECT_CI, FIRST_MILESTONE_ID).should.be.fulfilled
+      refundInfoOneMonthAfterRefund[0].should.be.equal(true)
+      refundInfoOneMonthAfterRefund[1].should.be.bignumber.equal(refundValue / RATE)
 
       const { logs } = await refundManager.withdraw(ADVANCE_PROJECT_CI, FIRST_MILESTONE_ID)
         .should.be.fulfilled


### PR DESCRIPTION
- Provide a view function `getRefundInfo` to get withdrawState,
  ethRefund, availableTime
- Add tests for above changes in `refundManager.js`.