### PR TITLE
Fix #308 PaymentManager unit test

### DIFF
--- a/solidity/contracts/modules/managers/payment_manager/PaymentManager.sol
+++ b/solidity/contracts/modules/managers/payment_manager/PaymentManager.sol
@@ -20,12 +20,29 @@ contract PaymentManager is Manager {
     }
 
     /**
+    * Get the rest wei lock, how much ETHER(wei) can withdraw/refund
+    *
+    *  @param namespace namespace of the project
+    *  @param milestoneId the id of a milestone
+    *  @return the rest wei lock
+    */
+    function getRestWeiLock(bytes32 namespace, uint milestoneId) public view returns(uint) {
+        // check the milestone state at least IN PROCESS (IP)
+        uint milestoneState = milestoneController.milestoneState(namespace, milestoneId);
+        require(milestoneState >= uint(MilestoneController.MilestoneState.IP));
+
+        uint restWeiLocked = etherCollector.getDepositValue(
+            keccak256(abi.encodePacked(namespace, milestoneId, MILESTONE_ETHER_WEILOCKED)));
+        return restWeiLocked;
+    }
+
+    /**
     *  Release funds from a milestone to project founders
     *  The milestone should be in COMPLETE state
     *  The refundValue should be 
     *      init weiLocked - total refund in refundStage
     *
-    *  @param namespace namespace of the project]
+    *  @param namespace namespace of the project
     *  @param milestoneId the id of a milestone
     */
     function withdraw(bytes32 namespace, uint milestoneId) external founderOnly(namespace) {

--- a/solidity/test/modules/manager/paymentManager.js
+++ b/solidity/test/modules/manager/paymentManager.js
@@ -8,15 +8,16 @@ const PROJECT_THREE = Web3.utils.keccak256('ProjectThree')
 const MILESTONE_ID_ONE = 1
 const WEI_LOCKED = 100
 const TOTAL_SPEND_MONEY = 1000000
+const TOKEN_SALE_AMOUNT = 1000000
 const DEPOSIT_VALUE = 10000
 const RATE = 10
-const ETH_AMOUNT = 10
+const ETH_AMOUNT = 1000
 const DEPOSIT_ETH_VALUE = 1000
 const MILESTONE_LENGTH = TimeSetter.OneYear
 
 const OBJS = [Web3.utils.keccak256('obj1')]
 const OBJ_TYPES = ['type1']
-const OBJ_MAX_REGULATION_REWARDS = [100]
+const OBJ_MAX_REGULATION_REWARDS = [10]
 
 contract('PaymentManagerTest', function (accounts) {
   const FOUNDER = accounts[1]
@@ -53,14 +54,14 @@ contract('PaymentManagerTest', function (accounts) {
       OBJ_TYPES,
       OBJ_MAX_REGULATION_REWARDS, {from: FOUNDER}).should.be.fulfilled
 
+    await vetXToken.transfer(FOUNDER, TOKEN_SALE_AMOUNT)
+    await vetXToken.approve(tokenSale.address, TOKEN_SALE_AMOUNT, {from: FOUNDER})
     await tokenSale.startTokenSale(
       projectId,
       RATE,
       vetXToken.address,
+      TOKEN_SALE_AMOUNT,
       {from: FOUNDER}).should.be.fulfilled
-
-    await tokenCollector.deposit(vetXToken.address, DEPOSIT_VALUE)
-      .should.be.fulfilled
 
     await tokenSale.buyTokens(
       projectId,
@@ -81,9 +82,7 @@ contract('PaymentManagerTest', function (accounts) {
 
     await vetXToken.approve(tokenCollector.address, TOTAL_SPEND_MONEY)
     await vetXToken.approve(paymentManager.address, TOTAL_SPEND_MONEY)
-    await etherCollector.deposit({value: DEPOSIT_ETH_VALUE})
   })
-
 
   it('should withdraw successfully', async function () {
     let currentTime = TimeSetter.latestTime()
@@ -108,20 +107,22 @@ contract('PaymentManagerTest', function (accounts) {
     milestoneState.should.be.bignumber.equal(
       MilestoneController.State.COMPLETION)
 
+    const preEtherCollectorBalance = await web3.eth.getBalance(
+      etherCollector.address)
+
     await paymentManager.withdraw(
       PROJECT_ONE,
       MILESTONE_ID_ONE,
       {from: FOUNDER}).should.be.fulfilled
 
-    const etherCollectorBalance = await web3.eth.getBalance(
+    const postEtherCollectorBalance = await web3.eth.getBalance(
       etherCollector.address)
-    etherCollectorBalance.should.be.bignumber.equal(
-      DEPOSIT_ETH_VALUE - WEI_LOCKED)
+    preEtherCollectorBalance.minus(postEtherCollectorBalance)
+      .should.be.bignumber.equal(WEI_LOCKED)
 
-    const weiLocked = await milestoneController.milestoneWeiLocked.call(
+    const weiLocked = await paymentManager.getRestWeiLock.call(
       PROJECT_ONE, MILESTONE_ID_ONE);
     weiLocked.should.be.bignumber.equal(0)
-
   })
 
   it('should fail to withdraw if milestone state is not COMPLETION',

--- a/solidity/test/modules/token_sale/tokenSale.js
+++ b/solidity/test/modules/token_sale/tokenSale.js
@@ -127,6 +127,10 @@ contract('TokenSaleTest', function (accounts) {
       await tokenSale.buyTokens(
         testCI1, {value: ETH_AMOUNT, from: PURCHASER})
         .should.be.rejectedWith(Error.EVMRevert)
+
+      const tokenAddress = await projectController.getTokenAddress(testCI1)
+        .should.be.fulfilled
+      tokenAddress.should.be.equal(vetXToken.address)
     })
 
     it('should rejected cause project already finalized', async function () {


### PR DESCRIPTION
- Fix #306, test after TokenSale finalized, `ProjectController` getTokenAddress receive `0x0`
- Fix #308, fix the payment manager unit test after changes of pr#292
- Provide function `getRestWeiLock` to get rest wei lock for a milestone
  (For front-end)