### PR TITLE
Fix #318 RewardManager - getRegulationRewardsInfo

### DIFF
--- a/solidity/contracts/modules/managers/reward_manager/RewardManager.sol
+++ b/solidity/contracts/modules/managers/reward_manager/RewardManager.sol
@@ -24,6 +24,43 @@ contract RewardManager is Manager {
     }
 
     /*
+     * get the regulation rewards withdraw information 
+     *
+     * @param namespace namespace of the project
+     * @param milestoneId id of a milestone
+     * @param obj an objective of a milestone of the project
+     * @return
+     *      bool: check if this obj bid is finalize or not
+     *      uint: get the rewards for msg.sender that can withdraw. 
+     *            (If withdraw already, this value would be 0)
+     */
+    function getRegulationRewardsInfo(bytes32 namespace, uint milestoneId, bytes32 obj)
+        public
+        view
+        returns(bool, uint)
+    {
+        bytes32 alreadyWithdrawnKey = keccak256(abi.encodePacked(
+            namespace,
+            milestoneId,
+            obj,
+            msg.sender,
+            ALREADY_WITHDRAWN));
+
+        (bool finalized, uint rewards) = milestoneController.getRegulationRewardsForRegulator(
+            namespace,
+            milestoneId,
+            obj,
+            msg.sender
+        );
+
+        if (rewardManagerStore.getUint(alreadyWithdrawnKey) == TRUE) {
+            rewards = 0;
+        }
+
+        return (finalized, rewards);
+    }
+
+    /*
      * Withdraw reward by regulator after Rating Stage of the milestone
      *
      * @param namespace namespace of the project

--- a/solidity/test/modules/manager/rewardManager.js
+++ b/solidity/test/modules/manager/rewardManager.js
@@ -278,6 +278,17 @@ contract('RewardManagerTest', function (accounts) {
     expectedRegulatorTwoRewardForObjTwo.should.be.bignumber.equal(
       initBalance - newBalance)
 
+    /*
+     * test getRegulationRewardsInfo before withdraw
+     */
+    const rewardsInfoBeforeWithdraw = await rewardManager.getRegulationRewardsInfo(
+      PROJECT_ONE,
+      MILESTONE_ID_ONE,
+      OBJ_TWO,
+      {from: REGULATOR_ONE})
+    rewardsInfoBeforeWithdraw[0].should.be.equal(true)
+    rewardsInfoBeforeWithdraw[1].should.be.bignumber.equal(expectedRegulatorOneRewardForObjTwo)
+
     initBalance = newBalance
     await rewardManager.withdraw(
       PROJECT_ONE,
@@ -287,6 +298,17 @@ contract('RewardManagerTest', function (accounts) {
     newBalance = await web3.eth.getBalance(etherCollector.address)
     expectedRegulatorOneRewardForObjTwo.should.be.bignumber.equal(
       initBalance - newBalance)
+
+    /*
+     * test getRegulationRewardsInfo after withdraw
+     */
+    const rewardsInfoAfterWithdraw = await rewardManager.getRegulationRewardsInfo(
+      PROJECT_ONE,
+      MILESTONE_ID_ONE,
+      OBJ_TWO,
+      {from: REGULATOR_ONE})
+    rewardsInfoAfterWithdraw[0].should.be.equal(true)
+    rewardsInfoAfterWithdraw[1].should.be.bignumber.equal(0)
   })
 
   it('should fail to withdraw if an objective is not finalized',
@@ -330,8 +352,18 @@ contract('RewardManagerTest', function (accounts) {
       await regulatingRating.bid(
         PROJECT_TWO, MILESTONE_ID_ONE, OBJ_TWO, {from: REGULATOR_TWO})
 
+    /*
+     * test getRegulationRewardsInfo when not finalized
+     */
+    const rewardsInfoNotFinalized = await rewardManager.getRegulationRewardsInfo(
+      PROJECT_TWO,
+      MILESTONE_ID_ONE,
+      OBJ_TWO,
+      {from: REGULATOR_ONE})
+    rewardsInfoNotFinalized[0].should.be.equal(false)
+
       await rewardManager.withdraw(
-        PROJECT_ONE,
+        PROJECT_TWO,
         MILESTONE_ID_ONE,
         OBJ_TWO,
         {from: REGULATOR_ONE}).should.be.rejectedWith(Error.EVMRevert)


### PR DESCRIPTION
- RewardManager provide a view function `getRegulationRewardsInfo` to
  check if withdraw already or not
- Add unit test for above view function
- Fix unit test fail to withdraw not finalized project hash to
  PROJECT_TWO