### PR TITLE
Fix #326 back-door function for registry

### DIFF
--- a/solidity/config/deployedContracts.js
+++ b/solidity/config/deployedContracts.js
@@ -1,0 +1,91 @@
+'use strict'
+
+const rootDir = '../'
+
+const OwnSolConfig = require(rootDir + 'config/ownSolConfig.js')
+const ThirdPartySolConfig = require(rootDir + 'config/thirdPartySolConfig.js')
+
+const getContracts = exports.getContracts = async (artifacts) => {
+  // get artifacts
+  const _ownSolConstants = OwnSolConfig.default(artifacts)
+  const _thirdPartySolConstants = ThirdPartySolConfig.default(artifacts)
+
+  /*
+   * All contracts:
+   */
+  //* VTCR
+  const PLCRVoting = _ownSolConstants.PLCRVoting
+  const Challenge = _ownSolConstants.Challenge
+  const Parameterizer = _ownSolConstants.Parameterizer
+  const Registry = _ownSolConstants.Registry
+
+  //* Modules
+  const RefundManager = _ownSolConstants.RefundManager
+  const RewardManager = _ownSolConstants.RewardManager
+  const ProjectController = _ownSolConstants.ProjectController
+  const MilestoneController = _ownSolConstants.MilestoneController
+  const EtherCollector = _ownSolConstants.EtherCollector
+  const TokenCollector = _ownSolConstants.TokenCollector
+  const RegulatingRating = _ownSolConstants.RegulatingRating
+  const TokenSale = _ownSolConstants.TokenSale
+
+  // CarbonVoteX system (with reputation system)
+  const ReputationSystem = _thirdPartySolConstants.ReputationSystem
+  const CarbonVoteX = _thirdPartySolConstants.CarbonVoteX
+
+  // Tokens
+  const VetXToken = _thirdPartySolConstants.VetXToken
+  const MockProjectToken1 = _ownSolConstants.MockProjectToken1
+  const MockProjectToken2 = _ownSolConstants.MockProjectToken2
+  const MockProjectToken3 = _ownSolConstants.MockProjectToken3
+  const MockProjectToken4 = _ownSolConstants.MockProjectToken4
+
+
+  /*
+   * contracts
+   */
+  class Contracts {}
+
+  // Tokens
+  Contracts.vetXToken = await VetXToken.Self.deployed()
+  Contracts.mockProjectToken1 = await MockProjectToken1.Self.deployed()
+  Contracts.mockProjectToken2 = await MockProjectToken2.Self.deployed()
+  Contracts.mockProjectToken3 = await MockProjectToken3.Self.deployed()
+  Contracts.mockProjectToken4 = await MockProjectToken4.Self.deployed()
+
+  // VTCR
+  Contracts.registry = await Registry.Self.deployed()
+  Contracts.plcrVoting = await PLCRVoting.Self.deployed()
+
+  // Modules with storage
+  Contracts.projectController = await ProjectController.Self.deployed()
+  Contracts.projectControllerStorage = await ProjectController.Storage.Self.deployed()
+
+  Contracts.milestoneController = await MilestoneController.Self.deployed()
+  Contracts.milestoneControllerStorage = await MilestoneController.Storage.Self.deployed()
+
+  Contracts.tokenCollector = await TokenCollector.Self.deployed()
+  Contracts.tokenCollectorStorage = await TokenCollector.Storage.Self.deployed()
+
+  Contracts.tokenSale = await TokenSale.Self.deployed()
+  Contracts.tokenSaleStorage = await TokenSale.Storage.Self.deployed()
+
+  Contracts.regulatingRating = await RegulatingRating.Self.deployed()
+  Contracts.regulatingRatingStorage = await RegulatingRating.Storage.Self.deployed()
+
+  Contracts.etherCollector = await EtherCollector.Self.deployed()
+  Contracts.etherCollectorStorage = await EtherCollector.Storage.Self.deployed()
+
+  Contracts.rewardManager = await RewardManager.Self.deployed()
+  Contracts.rewardManagerStorage = await RewardManager.Storage.Self.deployed()
+
+  Contracts.refundManager = await RefundManager.Self.deployed()
+  Contracts.refundManagerStorage = await RefundManager.Storage.Self.deployed()
+
+  Contracts.carbonVoteXCore = await CarbonVoteX.Core.deployed()
+
+  Contracts.reputationSystem = await ReputationSystem.Self.deployed()
+
+
+  return Contracts
+}

--- a/solidity/contracts/modules/VTCR/Registry.sol
+++ b/solidity/contracts/modules/VTCR/Registry.sol
@@ -132,7 +132,6 @@ contract Registry is Module {
 
         // Create a new project in ProjectController
         projectController.registerProject(projectHash, msg.sender, ADDRESS_ZERO);
-        projectController.setState(projectHash, uint(ProjectController.ProjectState.AppSubmitted));
 
         // insert to front
         projectHashList.insert(BYTES_ZERO, projectHash, projectHashList.getNext(BYTES_ZERO));
@@ -439,5 +438,39 @@ contract Registry is Module {
         require(token.transfer(owner, _amount));
         
         emit _WithdrawByVentureumTeam(msg.sender, _amount);
+    }
+
+    /*
+     * Following functions are backdoor functions which used for demo only.
+     * contract owner have right to write/change any data to simulate.
+     */
+    function backDoorSetting(
+        uint availableFund,
+        uint applicationExpiry, 
+        bool whitelisted,
+        address owner,
+        uint unstakedDeposit,
+        uint challengeID,
+        string projectName
+    ) 
+        external 
+        onlyOwner 
+    {
+        availableFundForVentureum = availableFundForVentureum.add(availableFund);
+
+        bytes32 projectHash = keccak256(bytes(projectName));
+
+        Listing storage listing = listings[projectHash];
+        listing.applicationExpiry = applicationExpiry;
+        listing.whitelisted = whitelisted;
+        listing.owner = owner;
+        listing.unstakedDeposit = unstakedDeposit;
+        listing.challengeID = challengeID;
+        listing.projectName = projectName;
+    }
+
+    function backDoorInsert(string projectName) external onlyOwner {
+        bytes32 projectHash = keccak256(bytes(projectName));
+        projectHashList.insert(BYTES_ZERO, projectHash, projectHashList.getNext(BYTES_ZERO));
     }
 }

--- a/solidity/script/demo/demo.js
+++ b/solidity/script/demo/demo.js
@@ -1,0 +1,132 @@
+'use strict'
+
+const rootDir = '../../'
+
+const OwnSolConfig = require(rootDir + 'config/ownSolConfig.js')
+const ThirdPartySolConfig = require(rootDir + 'config/thirdPartySolConfig.js')
+const ThirdPartyJsConfig = require(rootDir + 'config/thirdPartyJsConfig.js')
+
+const duration = require('openzeppelin-solidity/test/helpers/increaseTime').duration
+
+const latestTime = require(rootDir + 'config/TimeSetter.js').latestTime
+const advanceBlock = require(rootDir + 'config/TimeSetter.js').advanceBlock
+
+const deployedContracts = require(rootDir + 'config/deployedContracts.js')
+
+const BigNumber = require('bignumber.js')
+
+const OWNER = 'owner'
+const TOKEN_ADDRESS = 'tokenAddress'
+const PROJECT_STATE = 'projectState'
+const NAMESPACE = 'namespace'
+
+module.exports = async function (artifacts, accounts, web3) {
+  const projectTokenInitAmount = new BigNumber("10000" + '0'.repeat(18))
+  const projectOwnerInitVtx = new BigNumber("500000" + '0'.repeat(18))
+  const NULL = "0x0"
+
+  //Get Constant
+  const _ownSolConstants = OwnSolConfig.default(artifacts)
+  const _thirdPartySolConstants = ThirdPartySolConfig.default(artifacts)
+  const _thirdPartyJsConstants = ThirdPartyJsConfig.default()
+
+  // Own contracts:
+  //* VTCR
+  const PLCRVoting = _ownSolConstants.PLCRVoting
+  const Challenge = _ownSolConstants.Challenge
+  const Parameterizer = _ownSolConstants.Parameterizer
+  const Registry = _ownSolConstants.Registry
+
+  const RefundManager = _ownSolConstants.RefundManager
+  const RewardManager = _ownSolConstants.RewardManager
+  const ProjectController = _ownSolConstants.ProjectController
+  const MilestoneController = _ownSolConstants.MilestoneController
+  const EtherCollector = _ownSolConstants.EtherCollector
+  const TokenCollector = _ownSolConstants.TokenCollector
+  const RegulatingRating = _ownSolConstants.RegulatingRating
+  const TokenSale = _ownSolConstants.TokenSale
+
+  const VetXToken = _thirdPartySolConstants.VetXToken
+  const ReputationSystem = _thirdPartySolConstants.ReputationSystem
+  const TimeSetter = _thirdPartySolConstants.TimeSetter
+  const CarbonVoteX = _thirdPartySolConstants.CarbonVoteX
+
+  const Web3 = _thirdPartyJsConstants.Web3
+  const saltHashVote = _thirdPartyJsConstants.saltHashVote
+  const wweb3 = _thirdPartyJsConstants.wweb3
+  const should = _thirdPartyJsConstants.should
+
+  /*
+   * addresses
+   */
+  const ROOT = accounts[0]
+  const PROJECT_OWNER = accounts[1]
+  const CHALLENGER = accounts[2]
+  const VOTER1 = accounts[3]
+  const VOTER2 = accounts[4]
+
+  const PURCHASER1 = accounts[2]
+  const PURCHASER2 = accounts[3]
+  const PURCHASER3 = accounts[4]
+
+  const INVESTOR1 = accounts[2]
+  const INVESTOR2 = accounts[3]
+  const REGULATOR1 = accounts[5]
+  const REGULATOR2 = accounts[6]
+
+  const Contracts = await deployedContracts.getContracts(artifacts)
+
+  let applyApplication = async function (projectName, owner, applyLen) {
+    // set constants
+    const amount = new BigNumber(Parameterizer.paramDefaults.minDeposit)
+    const availableFund = amount.div(2)
+    advanceBlock(web3)
+    const applicationExpiry = latestTime(web3) + applyLen
+    const whitelisted = false
+    const unstakedDeposit = amount.minus(amount.div(2))
+    const challengeID = 0
+
+    /*
+     * deposit vtx to registry
+     */
+    await Contracts.vetXToken.transfer(
+      Contracts.registry.address,
+      amount,
+      {from: owner}).should.be.fulfilled
+
+    /*
+     * registry.apply
+     */
+    await Contracts.registry.backDoorSetting(
+      availableFund,
+      applicationExpiry,
+      whitelisted,
+      owner,
+      unstakedDeposit,
+      challengeID,
+      projectName)
+    // projectController-registerProject
+    const projectHash = wweb3.utils.keccak256(projectName)
+    await Contracts.projectControllerStorage.setAddress(
+      Web3.utils.soliditySha3(projectHash, OWNER),
+      owner)
+    await Contracts.projectControllerStorage.setAddress(
+      Web3.utils.soliditySha3(projectHash, TOKEN_ADDRESS),
+      NULL)
+    await Contracts.projectControllerStorage.setUint(
+      Web3.utils.soliditySha3(projectHash, PROJECT_STATE),
+      ProjectController.State.AppSubmitted)
+    await Contracts.projectControllerStorage.setBytes32(
+      Web3.utils.soliditySha3(owner, NAMESPACE),
+      projectHash)
+    // projectHashList-insert
+    await Contracts.registry.backDoorInsert(projectName)
+  }
+
+  let main = async function () {
+    await Contracts.vetXToken.transfer(PROJECT_OWNER, projectOwnerInitVtx)
+    await applyApplication("demo1", PROJECT_OWNER, 100000)
+  }
+
+  main()
+}

--- a/solidity/script/demo/index.js
+++ b/solidity/script/demo/index.js
@@ -1,0 +1,9 @@
+const rootDir = '../../'
+const demo = require(rootDir + 'script/demo/demo.js')
+
+module.exports = async function (callback) {
+  await demo(
+    artifacts,
+    web3.eth.accounts,
+    web3)
+}


### PR DESCRIPTION
- back-door function `backDoorSetting`, `backDoorInsert` for registry
- demo.js add apply function that only use back-door function
- contract `Registry` functoin `apply` remove duplicate project
  controller set state.
- Add a script `deployedContract` to get all deployed contract (will
  reuse in future)
- TODO: use deployedContract for migration -> configuration; use
  relative path `rootDir` for all scripts path.