### PR TITLE
Fix #325 Use rootDir in all config/script

### DIFF
--- a/solidity/config/configuration.js
+++ b/solidity/config/configuration.js
@@ -1,7 +1,9 @@
 'use strict'
 
-const ThirdPartySolConstants = require('../config/thirdPartySolConfig.js')
-const OwnSolConstants = require('../config/ownSolConfig.js')
+const rootDir = '../'
+
+const ThirdPartySolConstants = require(rootDir + 'config/thirdPartySolConfig.js')
+const OwnSolConstants = require(rootDir + 'config/ownSolConfig.js')
 
 const run = exports.run = async (instances, accounts, artifacts) => {
   const root = accounts[0]

--- a/solidity/config/migrationConfiguration.js
+++ b/solidity/config/migrationConfiguration.js
@@ -1,7 +1,9 @@
 'use strict'
 
-const ThirdPartySolConstants = require('../config/thirdPartySolConfig.js')
-const OwnSolConstants = require('../config/ownSolConfig.js')
+const rootDir = '../'
+
+const ThirdPartySolConstants = require(rootDir + 'config/thirdPartySolConfig.js')
+const OwnSolConstants = require(rootDir + 'config/ownSolConfig.js')
 
 exports.initMockData = async (instances, accounts, artifacts) => {
   const _thirdPartySolConstants = ThirdPartySolConstants.default(artifacts)

--- a/solidity/config/ownSolConfig.js
+++ b/solidity/config/ownSolConfig.js
@@ -1,4 +1,6 @@
-const ThirdPartyJsConfig = require("../config/thirdPartyJsConfig.js")
+const rootDir = '../'
+
+const ThirdPartyJsConfig = require(rootDir + "config/thirdPartyJsConfig.js")
 
 const toWei = function (num) {
   return num.toString() + '0'.repeat(18)

--- a/solidity/config/thirdPartySolConfig.js
+++ b/solidity/config/thirdPartySolConfig.js
@@ -1,10 +1,11 @@
-import { increaseTimeTo, duration } from
-  'openzeppelin-solidity/test/helpers/increaseTime'
+import { increaseTimeTo, duration } from 'openzeppelin-solidity/test/helpers/increaseTime'
 import latestTime from 'openzeppelin-solidity/test/helpers/latestTime'
 import EVMRevert from 'openzeppelin-solidity/test/helpers/EVMRevert'
 import { advanceBlock } from 'openzeppelin-solidity/test/helpers/advanceToBlock'
 
-const ThirdPartyJsConfig = require("../config/thirdPartyJsConfig.js")
+const rootDir = '../'
+
+const ThirdPartyJsConfig = require(rootDir + "config/thirdPartyJsConfig.js")
 
 export default function (artifacts) {
   const _thirdPartyJsConstants = ThirdPartyJsConfig.default()

--- a/solidity/migrations/2_migrate_contracts.js
+++ b/solidity/migrations/2_migrate_contracts.js
@@ -3,8 +3,8 @@
 const OwnSolConfig = require('../config/ownSolConfig.js')
 const ThirdPartySolConfig = require('../config/thirdPartySolConfig.js')
 
-const Configuation = require('../config/configuation.js')
-const MigrationConfiguation = require('../config/migrationConfiguation.js')
+const Configuration = require('../config/configuration.js')
+const MigrationConfiguration = require('../config/migrationConfiguration.js')
 
 const duration = require('openzeppelin-solidity/test/helpers/increaseTime').duration
 
@@ -284,8 +284,8 @@ module.exports = function (deployer, network, accounts) {
         Registry.Self.address)
 
       // Configuration
-      await Configuation.run(instances, accounts, artifacts)
-      await MigrationConfiguation.initMockData(instances, accounts, artifacts)
+      await Configuration.run(instances, accounts, artifacts)
+      await MigrationConfiguration.initMockData(instances, accounts, artifacts)
 
       const presale = Presale.Self.at(Presale.Self.address)
       const vetXToken = VetXToken.Self.at(VetXToken.Self.address)

--- a/solidity/script/advanceBlock.js
+++ b/solidity/script/advanceBlock.js
@@ -1,4 +1,5 @@
-const advanceBlock = require('./../config/TimeSetter.js').advanceBlock
+const rootDir = '../'
+const advanceBlock = require(rootDir + 'config/TimeSetter.js').advanceBlock
 
 module.exports = async function (callback) {
   await advanceBlock(web3)

--- a/solidity/script/increaseTime.js
+++ b/solidity/script/increaseTime.js
@@ -1,6 +1,8 @@
-const increaseTimeTo = require('./../config/TimeSetter.js').increaseTimeTo
-const latestTime = require('./../config/TimeSetter.js').latestTime
-const advanceBlock = require('./../config/TimeSetter.js').advanceBlock
+const rootDir = "../"
+
+const increaseTimeTo = require(rootDir + 'config/TimeSetter.js').increaseTimeTo
+const latestTime = require(rootDir + 'config/TimeSetter.js').latestTime
+const advanceBlock = require(rootDir + 'config/TimeSetter.js').advanceBlock
 const duration = require('openzeppelin-solidity/test/helpers/increaseTime').duration
 
 module.exports = async function (callback) {

--- a/solidity/script/stepJumpScript/addMilestone.js
+++ b/solidity/script/stepJumpScript/addMilestone.js
@@ -1,5 +1,7 @@
-const main = require("./mainScript.js")
-const mockData = require("./mockData.js")
+const rootDir = "../../"
+
+const main = require(rootDir + "script/stepJumpScript/mainScript.js")
+const mockData = require(rootDir + "script/stepJumpScript/mockData.js")
 
 module.exports = async function (callback) {
   const data = mockData(artifacts)

--- a/solidity/script/stepJumpScript/mainScript.js
+++ b/solidity/script/stepJumpScript/mainScript.js
@@ -1,19 +1,18 @@
 'use strict'
 
-const OwnSolConfig = require('../config/ownSolConfig.js')
-const ThirdPartySolConfig = require('../config/thirdPartySolConfig.js')
-const ThirdPartyJsConfig = require('../config/thirdPartyJsConfig.js')
+const rootDir = "../../"
 
-const Configuation = require('../config/configuation.js')
-const MigrationConfiguation = require('../config/migrationConfiguation.js')
+const OwnSolConfig = require(rootDir + 'config/ownSolConfig.js')
+const ThirdPartySolConfig = require(rootDir + 'config/thirdPartySolConfig.js')
+const ThirdPartyJsConfig = require(rootDir + 'config/thirdPartyJsConfig.js')
 
 const duration = require('openzeppelin-solidity/test/helpers/increaseTime').duration
 
 const mockData = require("./mockData.js")
 
-const latestTime = require('./../config/TimeSetter.js').latestTime
-const increaseTimeTo = require('./../config/TimeSetter.js').increaseTimeTo
-const advanceBlock = require('./../config/TimeSetter.js').advanceBlock
+const latestTime = require(rootDir + 'config/TimeSetter.js').latestTime
+const increaseTimeTo = require(rootDir + 'config/TimeSetter.js').increaseTimeTo
+const advanceBlock = require(rootDir + 'config/TimeSetter.js').advanceBlock
 
 module.exports = function (JumpId, MilestoneId, artifacts, accounts, web3) {
   //Get Constant

--- a/solidity/script/stepJumpScript/milestoneActivate.js
+++ b/solidity/script/stepJumpScript/milestoneActivate.js
@@ -1,5 +1,7 @@
-const main = require("./mainScript.js")
-const mockData = require("./mockData.js")
+const rootDir = '../../'
+
+const main = require(rootDir + "script/stepJumpScript/mainScript.js")
+const mockData = require(rootDir + "script/stepJumpScript/mockData.js")
 
 module.exports = async function (callback) {
   const data = mockData(artifacts)
@@ -14,7 +16,7 @@ module.exports = async function (callback) {
   }
 
   await main(
-    data.STATES.MILESTONE_REGULATING,
+    data.STATES.MILESTONE_ACTIVATE,
     MILESTONE_ID,
     artifacts,
     web3.eth.accounts,

--- a/solidity/script/stepJumpScript/milestoneBegin.js
+++ b/solidity/script/stepJumpScript/milestoneBegin.js
@@ -1,5 +1,7 @@
-const main = require("./mainScript.js")
-const mockData = require("./mockData.js")
+const rootDir = '../../'
+
+const main = require(rootDir + "script/stepJumpScript/mainScript.js")
+const mockData = require(rootDir + "script/stepJumpScript/mockData.js")
 
 module.exports = async function (callback) {
   const data = mockData(artifacts)

--- a/solidity/script/stepJumpScript/milestoneRefund.js
+++ b/solidity/script/stepJumpScript/milestoneRefund.js
@@ -1,5 +1,7 @@
-const main = require("./mainScript.js")
-const mockData = require("./mockData.js")
+const rootDir = '../../'
+
+const main = require(rootDir + "script/stepJumpScript/mainScript.js")
+const mockData = require(rootDir + "script/stepJumpScript/mockData.js")
 
 module.exports = async function (callback) {
   const data = mockData(artifacts)
@@ -14,7 +16,7 @@ module.exports = async function (callback) {
   }
 
   await main(
-    data.STATES.MILESTONE_ACTIVATE,
+    data.STATES.MILESTONE_REFUND,
     MILESTONE_ID,
     artifacts,
     web3.eth.accounts,

--- a/solidity/script/stepJumpScript/milestoneRegulating.js
+++ b/solidity/script/stepJumpScript/milestoneRegulating.js
@@ -1,5 +1,7 @@
-const main = require("./mainScript.js")
-const mockData = require("./mockData.js")
+const rootDir = '../../'
+
+const main = require(rootDir + "script/stepJumpScript/mainScript.js")
+const mockData = require(rootDir + "script/stepJumpScript/mockData.js")
 
 module.exports = async function (callback) {
   const data = mockData(artifacts)
@@ -14,7 +16,7 @@ module.exports = async function (callback) {
   }
 
   await main(
-    data.STATES.MILESTONE_REFUND,
+    data.STATES.MILESTONE_REGULATING,
     MILESTONE_ID,
     artifacts,
     web3.eth.accounts,

--- a/solidity/script/stepJumpScript/mockData.js
+++ b/solidity/script/stepJumpScript/mockData.js
@@ -1,7 +1,9 @@
 'use strict'
 
-const OwnSolConfig = require('../config/ownSolConfig.js')
-const ThirdPartySolConfig = require('../config/thirdPartySolConfig.js')
+const rootDir = '../../'
+
+const OwnSolConfig = require(rootDir + 'config/ownSolConfig.js')
+const ThirdPartySolConfig = require(rootDir + 'config/thirdPartySolConfig.js')
 
 const BigNumber = require('bignumber.js')
 

--- a/solidity/script/stepJumpScript/tokenSale.js
+++ b/solidity/script/stepJumpScript/tokenSale.js
@@ -1,5 +1,7 @@
-const main = require("./mainScript.js")
-const mockData = require("./mockData.js")
+const rootDir = '../../'
+
+const main = require(rootDir + "script/stepJumpScript/mainScript.js")
+const mockData = require(rootDir + "script/stepJumpScript/mockData.js")
 
 module.exports = async function (callback) {
   const data = mockData(artifacts)

--- a/solidity/script/stepJumpScript/vtcrWhitelist.js
+++ b/solidity/script/stepJumpScript/vtcrWhitelist.js
@@ -1,5 +1,7 @@
-const main = require("./mainScript.js")
-const mockData = require("./mockData.js")
+const rootDir = '../../'
+
+const main = require(rootDir + "script/stepJumpScript/mainScript.js")
+const mockData = require(rootDir + "script/stepJumpScript/mockData.js")
 
 module.exports = async function (callback) {
   const data = mockData(artifacts)

--- a/solidity/test/constants.js
+++ b/solidity/test/constants.js
@@ -1,6 +1,8 @@
-const OwnSolConfig = require('../config/ownSolConfig.js')
-const ThirdPartySolConfig = require('../config/thirdPartySolConfig.js')
-const ThirdPartyJsConfig = require('../config/thirdPartyJsConfig.js')
+const rootDir = '../'
+
+const OwnSolConfig = require(rootDir + 'config/ownSolConfig.js')
+const ThirdPartySolConfig = require(rootDir + 'config/thirdPartySolConfig.js')
+const ThirdPartyJsConfig = require(rootDir + 'config/thirdPartyJsConfig.js')
 
 const _ownSolConstants = OwnSolConfig.default(artifacts)
 const _thirdPartySolConstants = ThirdPartySolConfig.default(artifacts)

--- a/solidity/test/shared.js
+++ b/solidity/test/shared.js
@@ -19,7 +19,9 @@ import {
   Registry,
   CarbonVoteX} from './constants.js'
 
-const Configuation = require('../config/configuation.js')
+const rootDir = '../'
+
+const Configuration = require(rootDir + 'config/configuration.js')
 
 const run = exports.run = async (accounts) => {
   let instances = {}
@@ -149,7 +151,7 @@ const run = exports.run = async (accounts) => {
     instances.projectController.address
   )
 
-  const instanceObjects = await Configuation.run(instances, accounts, artifacts)
+  const instanceObjects = await Configuration.run(instances, accounts, artifacts)
 
   return instanceObjects
 }


### PR DESCRIPTION
- Use relative path `rootDir` to make config/script path absolute
- Fix typo, "configuation" should be `configuration`,
  "migrationConfiguation" should be `migrationConfiguration`
- remove few unused import/require
- move all jump step scripts to folder: `stepJumpScript`